### PR TITLE
Fix compile error with purescript 0.12.5

### DIFF
--- a/src/Main.purs
+++ b/src/Main.purs
@@ -23,7 +23,7 @@ rootWidget = withBrowserRouter [] $ D.div'
   ]
 
 showArgs :: forall a. RouteHandlerArgs -> Widget HTML a
-showArgs = D.text <<< toString
+showArgs x = D.text (toString x)
 
 links :: forall a. Widget HTML a
 links = D.div'


### PR DESCRIPTION
Purescript 0.12.5 fails to build Main.purs. It complains:

```
[1/1 ConstrainedTypeUnified] src/Main.purs:26:12

  26  showArgs = D.text <<< toString
                 ^^^^^^^^^^^^^^^^^^^
  
  Could not match constrained type
  
    LiftWidget (Array ReactElement) t1 => t1 t2
  
  with type
  
    Widget (Array ReactElement) a0
  
  while trying to match type LiftWidget (Array ReactElement) t1 => t1 t2
    with type Widget (Array ReactElement) a0
  while checking that expression (compose text) toString
    has type { history :: UnImplemented
             , location :: { hash :: String
                           , key :: String
                           , pathname :: String
                           , search :: String
                           , state :: UnImplemented
                           }
             , match :: { isExact :: Boolean
                        , params :: UnImplemented
                        , path :: String
                        , url :: String
                        }
             }
             -> Widget (Array ReactElement) a0
  in value declaration showArgs
  
  where a0 is a rigid type variable
          bound at (line 26, column 12 - line 26, column 31)
        t2 is an unknown type
        t1 is an unknown type
```

This trivial change solves the issue without changing the meaning of the code.