### PR TITLE
Added 'redirect' widget to support changing location

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ You use `switch` to *exclusively* match routes. Only the *first* route that matc
 
 To allow the user to switch routes, you can provide links with `linkTo`.
 
+To navigate to new location, use `redirect` widget.
+
 ## Example
 
 A simple example with dynamic routes is available at https://github.com/ajnsit/purescript-concur-react-router/blob/master/src/Main.purs.

--- a/src/Concur/React/Router.purs
+++ b/src/Concur/React/Router.purs
@@ -1,11 +1,11 @@
 module Concur.React.Router where
 
 import Concur.Core (Widget, wrapViewEventFunc)
-import Concur.React (HTML, el, el')
+import Concur.React (HTML, el, el', elLeaf)
 import Concur.React.DOM (El1, El)
 import Concur.React.Props as P
-import Concur.React.Router.FFI (_browserRouter, _hashRouter, _link, _route, _switch)
-import Concur.React.Router.Types (RoutePattern, RouteHandlerArgs, getPathFrom, isExact)
+import Concur.React.Router.FFI (_browserRouter, _hashRouter, _link, _route, _switch, _redirect)
+import Concur.React.Router.Types (RoutePattern, RouteHandlerArgs, Redirect, getPathFrom, isExact)
 import Data.Maybe (Maybe(..))
 import Data.Monoid ((<>))
 import Effect.Uncurried (mkEffectFn1)
@@ -68,3 +68,9 @@ location = P.unsafeMkProp "location"
 -- | Switch between multiple routes
 switch :: El
 switch = el' _switch
+
+-- | Change route. Rendering this widget will navigate to a new location. The 
+-- new location will override the current location in the history stack, like 
+-- server-side redirects (HTTP 3xx) do.
+redirect :: forall a. Redirect -> Widget HTML a
+redirect r = elLeaf _redirect [P.unsafeMkProp "to" r.to, P.unsafeMkProp "push" r.push]

--- a/src/Concur/React/Router/FFI.js
+++ b/src/Concur/React/Router/FFI.js
@@ -3,6 +3,7 @@ exports._hashRouterComponent = require("react-router-dom").HashRouter;
 exports._routeComponent = require("react-router-dom").Route;
 exports._switchComponent = require("react-router-dom").Switch;
 exports._linkComponent = require("react-router-dom").Link;
+exports._redirectComponent = require("react-router-dom").Redirect;
 
 function debugShow(s) {
     return function(a) {

--- a/src/Concur/React/Router/FFI.purs
+++ b/src/Concur/React/Router/FFI.purs
@@ -14,6 +14,7 @@ foreign import _hashRouterComponent :: ForeignRouterReactComponent
 foreign import _routeComponent :: ForeignRouterReactComponent
 foreign import _switchComponent :: ForeignRouterReactComponent
 foreign import _linkComponent :: ForeignRouterReactComponent
+foreign import _redirectComponent :: ForeignRouterReactComponent
 
 _browserRouter :: Array R.Props -> Array ReactElement -> ReactElement
 _browserRouter props children = createElement _browserRouterComponent (unsafeFromPropsArray props :: {}) children
@@ -29,6 +30,9 @@ _link props = createElement _linkComponent (unsafeFromPropsArray props :: {})
 
 _switch :: Array R.Props -> Array ReactElement -> ReactElement
 _switch props = createElement _switchComponent (unsafeFromPropsArray props :: {})
+
+_redirect :: Array R.Props -> ReactElement
+_redirect props = createElement _redirectComponent (unsafeFromPropsArray props :: {}) mempty
 
 -- Debugging only
 foreign import debugShow :: forall a. String -> a -> Effect Unit

--- a/src/Concur/React/Router/Types.purs
+++ b/src/Concur/React/Router/Types.purs
@@ -38,6 +38,12 @@ data RoutePattern
   | Exact String
   | InExact String
 
+type Redirect = 
+  { to :: String
+    -- ^ TODO: Support for state
+  , push :: Boolean
+  }
+
 getPathFrom :: RoutePattern -> Maybe String
 getPathFrom CatchAll = Nothing
 getPathFrom (Exact s) = Just s

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -6,7 +6,7 @@ import Concur.Core (Widget)
 import Concur.React (HTML)
 import Concur.React.DOM as D
 import Concur.React.Props as P
-import Concur.React.Router (linkTo, route, switch, withBrowserRouter)
+import Concur.React.Router (linkTo, route, switch, withBrowserRouter, redirect)
 import Concur.React.Router.FFI (toString)
 import Concur.React.Router.Types (RoutePattern(..), RouteHandlerArgs)
 import Concur.React.Run (runWidgetInDom)
@@ -45,7 +45,7 @@ pagesetWithUsers = switch []
          void $ D.button [P.onClick] [D.text "If you click the button one more time, the users page will disappear!"]
     ]
   , route (Exact "/users") \args -> D.h1' [D.text "Users page"]
-  , route CatchAll \args -> D.h1' [D.text "404 page"]
+  , route CatchAll \args -> notFound
   ]
 
 pagesetWithoutUsers :: forall a. Widget HTML a
@@ -55,5 +55,14 @@ pagesetWithoutUsers = switch []
     , D.div'
       [D.text "Now you've done it! There is no more /users page! Dynamic route configuration!"]
     ]
- , route CatchAll \args -> D.h1' [D.text "404 page"]
+ , route CatchAll \args -> notFound
  ]
+
+notFound :: forall a. Widget HTML a
+notFound = D.h1' 
+  [ D.text "404 page"
+  , D.div' 
+    [ D.button [P.onClick] [D.text "Redirect 404 to ABOUT"] >>= \_ -> 
+      redirect { to: "/about", push: false }
+    ]
+  ]


### PR DESCRIPTION
This adds a widget for `<Redirect>` element from `react-router-dom`. It's not complete (passing state is not supported as well as using `<Redirect>` elements as `<Switch>` children), but seems to work.